### PR TITLE
Allow custom page size

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -11,6 +11,7 @@
 
 - `ENABLE_VOTING`: Enable voting feature, set to "1" to enable voting. (default: 0).
 - `ENABLE_SYNTAX_HIGHLIGHTING`: Enable the ability to set a code style for syntax highlighting (admin only).
+- `ITEMS_PER_PAGE`: Set how many quotes should be displayed per page. (default: 5).
 
 ## Guest settings
 

--- a/src/includes/common.php
+++ b/src/includes/common.php
@@ -14,6 +14,7 @@ $cfg->set(
         'DB_NAME' => 'faridoon',
         'DB_HOST' => 'mysql',
         'SITE_TITLE' => 'Faridoon',
+        'ITEMS_PER_PAGE' => 5,
     ]
 );
 $cfg->loadFromPaths(

--- a/src/includes/common.php
+++ b/src/includes/common.php
@@ -35,6 +35,7 @@ DatabaseFactory::registerInstance($db);
 require_once 'includes/startup.php';
 
 requireDatabaseVersion('3.charset-utf8mb4.sql');
+validateConfig();
 
 require_once 'includes/functionality.php';
 

--- a/src/includes/startup.php
+++ b/src/includes/startup.php
@@ -48,6 +48,7 @@ function requireDatabaseVersion(string $requiredMigration)
 
 function validateConfig() {
     // Validate ITEMS_PER_PAGE
+    global $cfg;
     $limit = filter_var($cfg->get('ITEMS_PER_PAGE'), FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
     if ($limit === false) {
         startupError('ITEMS_PER_PAGE must be a positive integer');

--- a/src/includes/startup.php
+++ b/src/includes/startup.php
@@ -45,3 +45,11 @@ function requireDatabaseVersion(string $requiredMigration)
         startupError('Faridoon requires database version ' . $requiredMigration . ' but the database is at version ' . $latestVersion . '. Please <a href = "http://jamesread.github.io/Faridoon/installation/migrations/">run database migrations</a>.');
     }
 }
+
+function validateConfig() {
+    // Validate ITEMS_PER_PAGE
+    $limit = filter_var($cfg->get('ITEMS_PER_PAGE'), FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+    if ($limit === false) {
+        startupError('ITEMS_PER_PAGE must be a positive integer');
+    }
+}

--- a/src/list.php
+++ b/src/list.php
@@ -4,7 +4,9 @@ require_once 'includes/widgets/header.php';
 
 use faridoon\Quote;
 
-$limit = 5;
+global $cfg;
+
+$limit = $cfg->get('ITEMS_PER_PAGE');
 $order = filter('order');
 $page = filter('page');
 $page = $page == null ? 0 : $page;


### PR DESCRIPTION
# PR Introduction

This PR adds a config variable to allow admins to override the page size from the default 5.

# Checklist
Please put a X in the boxes as evidence of reading through the checklist.

- [X] I have forked the project, and raised this PR on a feature branch.
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide and understand the 3-line change suggestion.
- [X] The default `make` lint tasks run without any issues.
- [X] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable pagination for quote listings via `ITEMS_PER_PAGE`, defaulting to 5.

- **Documentation**
  - Documented the new `ITEMS_PER_PAGE` setting and its default value.

- **Bug Fixes**
  - Added validation to ensure `ITEMS_PER_PAGE` is a positive integer, preventing invalid configuration from breaking pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->